### PR TITLE
Feat: Add option to change Card icon

### DIFF
--- a/cypress/test-server/src/components/HelloWorld.vue
+++ b/cypress/test-server/src/components/HelloWorld.vue
@@ -75,6 +75,7 @@ export default defineComponent({
       this.$dialog.create({
         title: "My dialog",
         text: "Hello world!",
+        icon: "mdi-cookie",
         buttons: [
           { key: 'button1', title: 'Button 1', variant: 'outlined', color: 'error' },
           { key: 'button2', title: 'Button 2', variant: 'tonal', color: 'success' }

--- a/src/Dialog.ts
+++ b/src/Dialog.ts
@@ -118,6 +118,7 @@ export function confirmDialog(options: ConfirmDialogOptions) {
         ...options.confirmationButtonOptions,
       },
     ],
+    icon: options.icon,
     level: options.level,
     cardOptions: options.cardOptions,
   });

--- a/src/Dialog.ts
+++ b/src/Dialog.ts
@@ -38,6 +38,7 @@ export function createDialog(options: CreateDialogOptions) {
         title: options.title,
         text: options.text,
         buttons: options.buttons,
+        icon: options.icon,
         level: options.level,
         customComponent: options.customComponent,
         dialogOptions: PluginContext.getPluginOptions().defaults?.dialog?.component ||

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -41,6 +41,7 @@ const _buttons = computed(() => {
 })
 
 const _icon = computed(() => {
+  if (props.icon) return props.icon;
   switch (props.level) {
     case 'info':
       return 'mdi-information'

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type BasicDialogOptions = {
 export type ConfirmDialogOptions = {
   title: string;
   text: string;
+  icon?: string;
   level?: Level;
   cancelText?: string;
   confirmationText?: string;
@@ -49,6 +50,7 @@ export type CreateDialogOptions = {
   title: string;
   text: string;
   buttons?: DialogButton[];
+  icon?: string;
   level?: Level;
   customComponent?: ComponentOptions;
   dialogOptions?: VDialog['$props'];


### PR DESCRIPTION
Allows to overwrite the default Card icon. Took advantage of preexisting unused Dialog's `icon` prop.