### PR TITLE
Fix: Dialog PluginOptions defaults taking precedence over component dialogOptions

### DIFF
--- a/src/Dialog.ts
+++ b/src/Dialog.ts
@@ -41,8 +41,7 @@ export function createDialog(options: CreateDialogOptions) {
         icon: options.icon,
         level: options.level,
         customComponent: options.customComponent,
-        dialogOptions: PluginContext.getPluginOptions().defaults?.dialog?.component ||
-          options.dialogOptions || {
+        dialogOptions: options.dialogOptions || PluginContext.getPluginOptions().defaults?.dialog?.component || {
             width: '400px',
           },
         cardOptions: options.cardOptions || PluginContext.getPluginOptions().defaults?.dialog?.card || undefined,


### PR DESCRIPTION
Previous to this fix, using `defaults.dialog.component`:

```js
app.use(Vuetify3Dialog, {
  vuetify: vuetifyInstance,
  defaults: {
    dialog: {
      component: { width: 'auto' },
    },
  }
})
```

Would take precedence over `dialogOptions`:

```js
createDialog({
  customComponent: {
    component: MyCustomComponent,
  },
  dialogOptions: {
    width: "600px",
    persistent: true
  }
})
```