### PR TITLE
Update types namespace for Vue

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -95,7 +95,7 @@ export function createBottomSheetList(
 ): Promise<string>;
 
 //Vue augmented module declaration
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $dialog: {
       create: (options: CreateDialogOptions) => Promise<string>;


### PR DESCRIPTION
There is an issue with the Vue types that causes issues with other Vue libraries. We need to update the index.d.ts to the correct Vue module per their documentation. 

https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties