### PR TITLE
Fix warningDialog in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,7 +75,7 @@ export type CreateBottomSheetOptions = {
 
 //SFC dialogs methods
 export function createDialog(options: CreateDialogOptions): Promise<string>;
-export function warnDialog(options: BasicDialogOptions): Promise<string>;
+export function warningDialog(options: BasicDialogOptions): Promise<string>;
 export function errorDialog(options: BasicDialogOptions): Promise<string>;
 export function infoDialog(options: BasicDialogOptions): Promise<string>;
 export function successDialog(options: BasicDialogOptions): Promise<string>;


### PR DESCRIPTION
Apparently the lib now exports `warningDialog` instead of `warnDialog`, yet the index.d.ts definition remains unchanged. This needs to be fixed.