### PR TITLE
fix for vue module declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -96,9 +96,7 @@ export function createBottomSheetList(
 ): Promise<string>;
 
 //Vue augmented module declaration
-// TODO: figure out why it cannot be 'vue'
-// @ts-ignore: works on Vue 3, fails in Vue 2
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $dialog: {
       create: (options: CreateDialogOptions) => Promise<string>;


### PR DESCRIPTION
This library doesn't work with typescript and the latest vue router. The way the vue module is augmented is now incorrect per the vue docs: https://vuejs.org/api/utility-types#componentcustomproperties

